### PR TITLE
Change NameVirtualHost to eliminate warning on apache restart

### DIFF
--- a/contrib/securityonion_apache_site.conf
+++ b/contrib/securityonion_apache_site.conf
@@ -5,7 +5,7 @@
 # See /usr/share/doc/packages/apache2/README.QUICKSTART for further hints
 # about virtual hosts.
 Listen 3154
-NameVirtualHost localhost:3154
+NameVirtualHost *:3154
 <IfModule mod_ssl.c>
 <VirtualHost *:3154>
 	#  General setup for the virtual host


### PR DESCRIPTION
NameVirtualHost directives should always have a matching VirtualHost section with the same value.  Since one had "localhost:3154" and the other had "*:3154", the warning:

<pre>[warn] NameVirtualHost localhost:3154 has no VirtualHosts</pre>

was appearing whenever apache2 service was reloaded or restarted.  This patch simply changes the NameVirtualHost to match the VirtualHost section.
