### PR TITLE
Add bro's modbus and dnp3 logs to elsa.

### DIFF
--- a/contrib/parsers/bro_dnp3
+++ b/contrib/parsers/bro_dnp3
@@ -1,0 +1,29 @@
+<ruleset name="bro_dnp3" id="26019">
+  <pattern>bro_dnp3</pattern>
+  <rules>
+    <rule provider="Security_Onion" class="26019" id="26019">
+      <patterns>
+        <pattern>@ESTRING::|@@ESTRING::|@@ESTRING:i0:|@@ESTRING:i1:|@@ESTRING:i2:|@@ESTRING:i3:|@@ESTRING:s0:|@@ESTRING:s1:|@@ESTRING:i4:@</pattern>
+      </patterns>
+      <examples>
+        <example>
+          <test_message program="bro_dnp3">1436555953.765764|CnZKS10trXfqFTCu8|203.0.113.77|65438|192.168.3.5|502|READ|-|-</test_message>
+          <!-- srcip -->
+          <test_value name="i0">203.0.113.77</test_value>
+          <!-- srcport -->
+          <test_value name="i1">65438</test_value>
+          <!-- dstip -->
+          <test_value name="i2">192.168.3.5</test_value>
+          <!-- dstport -->
+          <test_value name="i3">502</test_value>
+          <!-- fc_request -->
+          <test_value name="s0">READ</test_value>
+          <!-- fc_reply -->
+          <test_value name="s1">-</test_value>
+          <!-- iin -->
+          <test_value name="i4">-</test_value>
+        </example>
+      </examples>
+    </rule>
+  </rules>
+</ruleset>   

--- a/contrib/parsers/bro_modbus
+++ b/contrib/parsers/bro_modbus
@@ -1,0 +1,27 @@
+<ruleset name="bro_modbus" id="26018">
+  <pattern>bro_modbus</pattern>
+  <rules>
+    <rule provider="Security_Onion" class="26018" id="26018">
+      <patterns>
+        <pattern>@ESTRING::|@@ESTRING::|@@ESTRING:i0:|@@ESTRING:i1:|@@ESTRING:i2:|@@ESTRING:i3:|@@ESTRING:s0:|@@ESTRING:s1:@</pattern>
+      </patterns>
+      <examples>
+        <example>
+          <test_message program="bro_modbus">1436555953.765764|CnZKS10trXfqFTCu8|203.0.113.77|65438|192.168.3.5|502|READ_HOLDING_REGISTERS|-</test_message>
+          <!-- srcip -->
+          <test_value name="i0">203.0.113.77</test_value>
+          <!-- srcport -->
+          <test_value name="i1">65438</test_value>
+          <!-- dstip -->
+          <test_value name="i2">192.168.3.5</test_value>
+          <!-- dstport -->
+          <test_value name="i3">502</test_value>
+          <!-- func -->
+          <test_value name="s0">READ_HOLDING_REGISTERS</test_value>
+          <!-- exception -->
+          <test_value name="s1">-</test_value>
+        </example>
+      </examples>
+    </rule>
+  </rules>
+</ruleset>   

--- a/contrib/securityonion-syslog-ng.conf
+++ b/contrib/securityonion-syslog-ng.conf
@@ -57,6 +57,8 @@ source s_bro_kerberos { file("/nsm/bro/logs/current/kerberos.log" flags(no-parse
 source s_bro_rdp { file("/nsm/bro/logs/current/rdp.log" flags(no-parse) program_override("bro_rdp")); };
 source s_bro_pe { file("/nsm/bro/logs/current/pe.log" flags(no-parse) program_override("bro_pe")); };
 source s_bro_sip { file("/nsm/bro/logs/current/sip.log" flags(no-parse) program_override("bro_sip")); };
+source s_bro_modbus { file("/nsm/bro/logs/current/modbus.log" flags(no-parse) program_override("bro_modbus")); };
+source s_bro_dnp3 { file("/nsm/bro/logs/current/dnp3.log" flags(no-parse) program_override("bro_dnp3")); };
 
 destination d_elsa { program("sh /opt/elsa/contrib/securityonion/contrib/securityonion-elsa-syslog-ng.sh" template(t_db_parsed)); };
 
@@ -86,6 +88,8 @@ log {
   	source(s_bro_rdp); 
   	source(s_bro_pe); 
   	source(s_bro_sip); 
+  	source(s_bro_modbus); 
+  	source(s_bro_dnp3); 
 	source(s_ossec);
 	source(s_network);
 	source(s_syslog);

--- a/contrib/securityonion_parsers_sql.sh
+++ b/contrib/securityonion_parsers_sql.sh
@@ -283,3 +283,11 @@ mysql -uroot < $SQL || echo "Error importing $SQL."
 # Additions for BRO_SIP class & associated fields
 SQL="$SQL_DIR/bro_sip.sql"
 mysql -uroot < $SQL || echo "Error importing $SQL."
+
+# Additions for BRO_MODBUS class & associated fields
+SQL="$SQL_DIR/bro_modbus.sql"
+mysql -uroot < $SQL || echo "Error importing $SQL."
+
+# Additions for BRO_DNP3 class & associated fields
+SQL="$SQL_DIR/bro_dnp3.sql"
+mysql -uroot < $SQL || echo "Error importing $SQL."

--- a/contrib/sql/bro_dnp3.sql
+++ b/contrib/sql/bro_dnp3.sql
@@ -1,0 +1,22 @@
+use syslog;
+
+/*  Create BRO_DNP3 class */
+INSERT IGNORE INTO classes (id, class) VALUES (26019, "BRO_DNP3");
+
+/* add new integers that don't already exist in fields table */
+INSERT IGNORE INTO fields (field, field_type, pattern_type) VALUES ("iin","int", "QSTRING");  
+
+/* add new strings that don't already exist in fields table */
+INSERT IGNORE INTO fields (field, field_type, pattern_type) VALUES ("fc_request","string", "QSTRING");  
+INSERT IGNORE INTO fields (field, field_type, pattern_type) VALUES ("fc_reply","string", "QSTRING");
+
+/* integers i0 through i5 are field order 5 through 10 */
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_DNP3"), (SELECT id FROM fields WHERE field="srcip"), 5);
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_DNP3"), (SELECT id FROM fields WHERE field="srcport"), 6);
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_DNP3"), (SELECT id FROM fields WHERE field="dstip"), 7);
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_DNP3"), (SELECT id FROM fields WHERE field="dstport"), 8);
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_DNP3"), (SELECT id FROM fields WHERE field="iin"), 9);
+
+/* strings s0 through s5 are field order 11 through 16 */
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_DNP3"), (SELECT id FROM fields WHERE field="fc_request"), 11);
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_DNP3"), (SELECT id FROM fields WHERE field="fc_reply"), 12);

--- a/contrib/sql/bro_modbus.sql
+++ b/contrib/sql/bro_modbus.sql
@@ -1,0 +1,18 @@
+use syslog;
+
+/*  Create BRO_MODBUS class */
+INSERT IGNORE INTO classes (id, class) VALUES (26018, "BRO_MODBUS");
+
+/* add new strings that don't already exist in fields table */
+INSERT IGNORE INTO fields (field, field_type, pattern_type) VALUES ("func","string", "QSTRING");  
+INSERT IGNORE INTO fields (field, field_type, pattern_type) VALUES ("exception","string", "QSTRING");
+
+/* integers i0 through i5 are field order 5 through 10 */
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_MODBUS"), (SELECT id FROM fields WHERE field="srcip"), 5);
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_MODBUS"), (SELECT id FROM fields WHERE field="srcport"), 6);
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_MODBUS"), (SELECT id FROM fields WHERE field="dstip"), 7);
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_MODBUS"), (SELECT id FROM fields WHERE field="dstport"), 8);
+
+/* strings s0 through s5 are field order 11 through 16 */
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_MODBUS"), (SELECT id FROM fields WHERE field="func"), 11);
+INSERT IGNORE INTO fields_classes_map (class_id, field_id, field_order) VALUES ((SELECT id FROM classes WHERE class="BRO_MODBUS"), (SELECT id FROM fields WHERE field="exception"), 12);


### PR DESCRIPTION
This pull request adds bro's modbus and dnp3 logs to elsa. This allows teams monitoring ICS systems to be able to query elsa for modbus and dnp3 specific traffic.
