### PR TITLE
Parse event ids 4776s appropriately

### DIFF
--- a/contrib/parsers/windows
+++ b/contrib/parsers/windows
@@ -86,6 +86,9 @@
 <rules>
     <rule provider="ELSA" class='4' id='4'>
         <patterns>
+            <!-- 4776s -->
+            <pattern>@NUMBER::@@ESTRING::) @@IPv4::->@@ESTRING::(@@ESTRING:i0:): @@ESTRING:: The domain controller attempted to validate the credentials for an account.@@ESTRING::Logon Account: @@ESTRING:s1: Source Workstation: @@ESTRING:s0: Error@</pattern>
+            
             <!-- 4740s -->
             <pattern>@NUMBER::@@ESTRING::) @@IPv4::->@@ESTRING::(@@ESTRING:i0:): @@ESTRING::A user account was locked out.@@ESTRING::Account Domain:  @@ESTRING:s2:  @@ESTRING::Account That Was Locked Out: @@ESTRING::Account Name:  @@ESTRING:s1:  @@ESTRING::Caller Computer Name: @@ESTRING:s0:@</pattern>
             <pattern>@NUMBER::@@ESTRING::) @@IPv4::->@@ESTRING::(@@ESTRING:i0:): @@ESTRING:::@@ESTRING:::@@ESTRING::: @@ESTRING:s0:: @@ESTRING::A user account was locked out.@@ESTRING::Account Domain:  @@ESTRING:s2:  @@ESTRING::Account That Was Locked Out: @@ESTRING::Account Name:  @@ESTRING:s1:  @</pattern>
@@ -423,6 +426,15 @@
                 <test_value name="s1">bsmith</test_value>
                 <!-- Source Network Address -->
                 <test_value name="i1">192.1.2.3</test_value>
+            </example>
+            <example>
+                <test_message program="ossec_archive">2015 Nov 03 19:57:04 (SERVER01) 10.1.1.1->WinEvtLog 2015 Nov 03 14:57:03 WinEvtLog: Security: AUDIT_FAILURE(4776): Microsoft-Windows-Security-Auditing: (no user): no domain: SERVER01.contoso.com: The domain controller attempted to validate the credentials for an account. Authentication Package: MICROSOFT_AUTHENTICATION_PACKAGE_V1_0 Logon Account: ttest Source Workstation: WORK01 Error Code: 0xc0000064</test_message>
+                <!-- Event ID -->
+                <test_value name="i0">4776</test_value>
+                <!-- Source Name -->
+                <test_value name="s0">WORK01</test_value>
+                <!-- User -->
+                <test_value name="s1">ttest</test_value>
             </example>
         </examples>
     </rule>


### PR DESCRIPTION
4776 events were not being properly parsed.  Added a parser to fix this.
