### PR TITLE
added 5140 parser

### DIFF
--- a/contrib/parsers/windows
+++ b/contrib/parsers/windows
@@ -360,7 +360,7 @@
 </ruleset>
 
 
-<!-- v. 9/23/2016 --- Brian Kellogg -->
+<!-- v. 1/30/2017 --- Brian Kellogg -->
 <ruleset name="WINDOWS" id='4'>
 <pattern>ossec_archive</pattern>
 <rules>
@@ -414,6 +414,9 @@
             <pattern>@NUMBER::@@ESTRING::) @@IPv4::->@@ESTRING::(@@ESTRING:i0:): @@ESTRING:::@@ESTRING:::@@ESTRING::: @@ESTRING:s0:: @Network Policy Server @ESTRING::\\@@ESTRING:s1:  Account Domain:   @@ESTRING:s2:  Fully@@ESTRING::Client IP Address:   @@IPv4:i1: @</pattern>
             <pattern>@NUMBER::@@ESTRING::) @@IPv4::->@@ESTRING::(@@ESTRING:i0:): @@ESTRING:::@@ESTRING:::@@ESTRING::: @@ESTRING:s0:: @Network Policy Server @ESTRING::Account Name:   @@ESTRING:s1:  Account Domain:   @@ESTRING:s2:  Fully@@ESTRING::Client IP Address:   @@IPv4:i1: @</pattern>
 
+            <!-- 5140s -->
+            <pattern>@NUMBER::@@ESTRING::) @@IPv4::->@@ESTRING::(@@ESTRING:i0:): @@ESTRING:::@@ESTRING:::@@ESTRING::: @@ESTRING:s0:: @@ESTRING::A network share object was accessed.@@ESTRING::Account Name:  @@ESTRING:s1: @@ESTRING::Account Domain:  @@ESTRING:s2: @@ESTRING::Source Address:  File  Source Port:  @@IPv4:i1: @</pattern>
+
             <!-- generic patterns -->
             <!--  Sometimes pipes in Win2003 logs are in one spot and sometimes another -->
             <pattern>@NUMBER::@@ESTRING::) @@IPv4::->@@ESTRING::(@@ESTRING:i0:): @@ESTRING:::@@ESTRING:::@@ESTRING::: @@ESTRING:s0:: @@ESTRING::User Name: |@@ESTRING:s1:    |@@ESTRING::Domain: |@@ESTRING:s2:    |@@ESTRING::Source Network Address: @@IPv4:i1: @</pattern>
@@ -439,6 +442,19 @@
 
         </patterns>
         <examples>
+             <example>
+                <test_message program="ossec_archive">2017 Jan 29 19:22:29 (TEST) 1.1.1.1->WinEvtLog 2017 Jan 29 13:22:26 WinEvtLog: Security: AUDIT_SUCCESS(5140): Microsoft-Windows-Security-Auditing: (no user): no domain: test.contoso.com: A network share object was accessed.  Subject:  Security ID:  S-1-5-21-126432666-12709346926-3688153413-10989949  Account Name:  USER01  Account Domain:  DOMAIN01  Logon ID:  0xdfa34d2  Network Information:   Source Address:  File  Source Port:  10.1.1.13   Share Name:   63305</test_message>
+                <!-- Event ID -->
+                <test_value name="i0">5140</test_value>
+                <!-- Source Name -->
+                <test_value name="s0">test.contoso.com</test_value>
+                <!-- User -->
+                <test_value name="s1">USER01</test_value>
+                <!-- Domain -->
+                <test_value name="s2">DOMAIN01</test_value>
+                <!-- Source Network Address -->
+                <test_value name="i1">10.1.1.13</test_value>
+            </example>
             <example>
                 <test_message program="ossec_archive">2015 Nov 03 19:57:01 (SERVER01) 10.1.1.1->WinEvtLog 2015 Nov 03 20:56:58 WinEvtLog: Security: AUDIT_SUCCESS(4776): Microsoft-Windows-Security-Auditing: (no user): no domain: SERVER01.contoso.com: The domain controller attempted to validate the credentials for an account. Authentication Package: MICROSOFT_AUTHENTICATION_PACKAGE_V1_0 Logon Account: user01 Source Workstation: WORKSTATION01 Error Code: 0x0</test_message>
                 <!-- Event ID -->


### PR DESCRIPTION
Noticed that event ID 5140s exhibit odd behavior when reporting source IP by including it in the log's source port field on file access.  Therefore added a parser to handle this.