### PR TITLE
refactor of securityonion-elsa-reset

### DIFF
--- a/bin/securityonion-elsa-reset
+++ b/bin/securityonion-elsa-reset
@@ -1,36 +1,191 @@
-#!/bin/sh
+#!/bin/bash
 
-[ `id -u` -ne 0 ] && echo "This script must be run using sudo!" && exit 1
 
-echo
-echo "This script will reset the ELSA database."
-echo
-echo "It should only be used as a last resort."
-echo
-echo "Continuing will delete any existing data in the ELSA database."
-echo
-echo "Type yes to continue or anything else to exit."
-read INPUT
-[ "$INPUT" != "yes" ] && exit 0
+#########################################
+# Variables
+#########################################
 
-echo
+# A banner for user output
+BANNER="----------------------------------------------------"
+
+# Log to file
+LOG=0
+
+# Reset ELSA index and archives
+RESET=0
+
+# Skip interactive key presses
+SKIP=0
+
+# View only mode
+VIEW=0
+
+
+#########################################
+# Got r00t?
+#########################################
+if [[ $(/usr/bin/id -u) -ne 0 ]]; then
+    echo "This script needs to be run as root.  Please try again using sudo."
+    exit
+fi
+
+
+#########################################
+# Options
+#########################################
+usage()
+{
+cat <<EOF
+
+Security Onion ELSA Reset
+
+  Options:
+  -h         This message
+  -l <file>  Log stdout and stderr to specified file (Use with '-y')
+  -r         Reset tables and files
+  -v         View only mode
+  -y         Skip interactive mode
+
+  Usage:
+    Show help file.
+    $0 -h
+
+    Show relevant ELSA tables and files.
+    $0 -v
+
+    Reset ELSA index and archives.
+    $0 -y -r
+
+EOF
+}
+
+
+view()
+{
+	echo $BANNER
+  echo "MySQL contents of 'syslog_data':"
+  mysql --defaults-file=/etc/mysql/debian.cnf syslog_data -e 'SHOW TABLES'
+
+  echo
+  echo "MySQL contents of 'syslog.tables':"
+  mysql --defaults-file=/etc/mysql/debian.cnf syslog -e 'SELECT * FROM tables'
+
+  echo
+  echo "Folder contents of '/nsm/elsa/data/elsa/mysql/':"
+  echo $BANNER
+  find /nsm/elsa/data/elsa/mysql/ -name 'syslogs*' | sort
+
+  echo
+  echo "Folder contents of '/var/lib/mysql/syslog_data/':"
+  echo $BANNER
+  find /var/lib/mysql/syslog_data/ -name 'syslogs*' | sort
+
+	echo
+}
+
+
+#########################################
+# Check if no arguments passed
+#########################################
+if [ $# -eq 0 ]; then
+	echo "error: argument required"
+
+	usage
+	exit 0
+	fi
+
+
+while getopts "hl:rvy" OPTION
+do
+     case $OPTION in
+			h)
+				usage
+				exit 0
+				;;
+			l)
+				LOG=1
+        LOGFILE="$OPTARG"
+        ;;
+			r)
+				RESET=1
+				;;
+			v)
+				VIEW=1
+				;;
+      y)
+				SKIP=1
+        ;;
+      *)
+				usage
+				exit 0
+				;;
+     esac
+done
+
+
+if [ $LOG -eq 1 ]; then
+	echo -e "\n --> Logging stdout & stderr to $LOGFILE"
+	exec > "$LOGFILE" 2>&1
+fi
+
+
+if [ $VIEW -eq 1 ]; then
+  view
+  exit 0
+  fi
+
+
+if [ $SKIP -ne 1 ]; then
+	# Prompt user to continue
+	echo $BANNER
+	echo "This script will reset the ELSA database."
+	echo
+	echo "Continuing will erase all data in the ELSA database."
+	echo
+	echo "Press Enter to continue or Ctrl-C to cancel."
+	read input
+	echo $BANNER
+fi
+
+
+if [ $RESET -ne 1 ]; then
+  echo "error: 'RESET' not specified, nothing to do"
+  usage
+  exit 0
+  fi
+
+
 echo "Stopping services..."
 service nsm stop
 service syslog-ng stop
+echo
+
+echo "Generating lists for removal:"
+echo "  accessing database 'syslog_data'"
+TABLES_SYSLOG_DATA=$(mysql --defaults-file=/etc/mysql/debian.cnf syslog_data --batch -e 'SHOW TABLES' | grep -v '^Table' | awk '{print "syslog_data."$1}')
+
+echo "  accessing table 'syslog.tables'"
+TABLES_SYSLOG=$(mysql --defaults-file=/etc/mysql/debian.cnf syslog --batch -e 'SELECT * FROM tables' | grep -v '^id' | awk '{print $2}')
 
 echo
-echo "Deleting database tables..."
-mysql --defaults-file=/etc/mysql/debian.cnf syslog_data -e "DROP TABLE syslog_data.syslogs_archive_1"
-mysql --defaults-file=/etc/mysql/debian.cnf syslog_data -e "DELETE FROM syslog.tables WHERE table_name='syslog_data.syslogs_archive_1'"
-mysql --defaults-file=/etc/mysql/debian.cnf syslog_data -e "DROP TABLE syslog_data.syslogs_index_1"
-mysql --defaults-file=/etc/mysql/debian.cnf syslog_data -e "DELETE FROM syslog.tables WHERE table_name='syslog_data.syslogs_index_1'"
+echo "Removing data:"
+echo "  deleting tables from 'syslog_data'"
+for t1 in $TABLES_SYSLOG_DATA
+do
+    mysql --defaults-file=/etc/mysql/debian.cnf syslog_data -e "DROP TABLE $t1"
+done
 
-echo
-echo "Cleaning up old database files..."
-rm /nsm/elsa/data/elsa/mysql/syslogs_archive_1*
-rm /var/lib/mysql/syslog_data/syslogs_archive_1*
-rm /nsm/elsa/data/elsa/mysql/syslogs_index_1*
-rm /var/lib/mysql/syslog_data/syslogs_index_1*
+echo "  deleting rows from 'syslog.tables'"
+for t2 in $TABLES_SYSLOG
+do
+    mysql --defaults-file=/etc/mysql/debian.cnf syslog -e "DELETE FROM syslog.tables WHERE table_name='$t2'"
+done
+
+echo "  deleting files from /var/lib/mysql/syslog_data/"
+find /var/lib/mysql/syslog_data/ -name 'syslogs*' -delete
+
+echo "  deleting files from /nsm/elsa/data/elsa/mysql/"
+find /nsm/elsa/data/elsa/mysql/ -name 'syslogs*' -delete
 
 echo
 echo "Restarting services..."
@@ -40,6 +195,9 @@ service nsm start
 
 echo
 echo "Done."
-echo "Please wait a minute or two and then log into ELSA"
-echo "to see if it is now showing a non-zero number of logs"
-echo "in the upper right corner."
+echo
+echo "Log onto ELSA and review 'logs indexed' and 'archived'"
+echo "statistics visible in the top right corner of the web console."
+echo "Depending on your ELSA configuration and activity on your"
+echo "network, these statistics will begin to climb."
+echo


### PR DESCRIPTION
Hello.

I needed to reset the ELSA database and used the 'securityonion-elsa-reset' script to do so.  Unfortunately it would not remove all the files.  I looked into this further and found the search criteria missed some of the database entries or files on the file system.

The database would, I believe, roll over to different archive files based on settings in settings in /etc/elsa_node.conf.  As a test, I set the "archive" "table_size" to "10" to cause more frequent roll overs.

Here is a snippet from using the -v option now available in the script.
```
$ sudo securityonion-elsa-reset -v
----------------------------------------------------
MySQL contents of 'syslog_data':
+-----------------------+
| Tables_in_syslog_data |
+-----------------------+
| syslogs_archive_1     |
| syslogs_archive_53    |
| syslogs_archive_73    |
| syslogs_index_1       |
+-----------------------+

MySQL contents of 'syslog.tables':
+------+--------------------------------+---------------------+---------------------+--------+--------+---------------+-----------------+
| id   | table_name                     | start               | end                 | min_id | max_id | table_type_id | table_locked_by |
+------+--------------------------------+---------------------+---------------------+--------+--------+---------------+-----------------+
| 6751 | syslog_data.syslogs_index_1    | 2017-02-08 01:55:48 | 2017-02-08 01:59:18 |      1 |     99 |             1 |            NULL |
| 6752 | syslog_data.syslogs_archive_1  | 2017-02-08 01:58:03 | 2017-02-08 01:58:03 |      1 |     52 |             2 |            NULL |
| 6753 | syslog_data.syslogs_archive_53 | 2017-02-08 01:59:02 | 2017-02-08 01:59:02 |     53 |     72 |             2 |            NULL |
| 6754 | syslog_data.syslogs_archive_73 | 2017-02-08 02:00:04 | 2017-02-08 02:00:04 |     73 |    102 |             2 |            NULL |
+------+--------------------------------+---------------------+---------------------+--------+--------+---------------+-----------------+

Folder contents of '/nsm/elsa/data/elsa/mysql/':
----------------------------------------------------
/nsm/elsa/data/elsa/mysql/syslogs_archive_1.ARZ
/nsm/elsa/data/elsa/mysql/syslogs_archive_53.ARZ
/nsm/elsa/data/elsa/mysql/syslogs_archive_73.ARZ
/nsm/elsa/data/elsa/mysql/syslogs_index_1.MYD
/nsm/elsa/data/elsa/mysql/syslogs_index_1.MYI

Folder contents of '/var/lib/mysql/syslog_data/':
----------------------------------------------------
/var/lib/mysql/syslog_data/syslogs_archive_1.ARZ
/var/lib/mysql/syslog_data/syslogs_archive_1.frm
/var/lib/mysql/syslog_data/syslogs_archive_53.ARZ
/var/lib/mysql/syslog_data/syslogs_archive_53.frm
/var/lib/mysql/syslog_data/syslogs_archive_73.ARZ
/var/lib/mysql/syslog_data/syslogs_archive_73.frm
/var/lib/mysql/syslog_data/syslogs_index_1.frm
/var/lib/mysql/syslog_data/syslogs_index_1.MYD
/var/lib/mysql/syslog_data/syslogs_index_1.MYI
```

'rm' did not seem to catch all the files, especially some of the symlinks so instead used 'find'.  Below is a sample of what the script looks like when running.
```
$ sudo securityonion-elsa-reset -y -r
Stopping services...
Stopping: securityonion
  * stopping: sguil server                            [  OK  ]
Stopping: HIDS
  * stopping: ossec_agent (sguil)                     [  OK  ]
Stopping: Bro
stopping bro ...
Stopping: vm-so-eth1
  * stopping: netsniff-ng (full packet data)          [  OK  ]
  * stopping: pcap_agent (sguil)                      [  OK  ]
  * stopping: snort_agent-1 (sguil)                   [  OK  ]
  * stopping: snort-1 (alert data)                    [  OK  ]
  * stopping: barnyard2-1 (spooler, unified2 format)  [  OK  ]
 * Stopping system logging syslog-ng                    [ OK ]

Generating lists for removal:
  accessing database 'syslog_data'
  accessing table 'syslog.tables'

Removing data:
  deleting tables from 'syslog_data'
  deleting rows from 'syslog.tables'
  deleting files from /var/lib/mysql/syslog_data/
  deleting files from /nsm/elsa/data/elsa/mysql/

Restarting services...
mysql stop/waiting
mysql start/running, process 44928
 * Stopping system logging syslog-ng                    [ OK ]
 * Starting system logging syslog-ng                    [ OK ]
Starting: securityonion
  * starting: sguil server                            [  OK  ]
Starting: HIDS
  * starting: ossec_agent (sguil)                     [  OK  ]
Starting: Bro
removing old policies in /nsm/bro/spool/installed-scripts-do-not-touch/site ...
removing old policies in /nsm/bro/spool/installed-scripts-do-not-touch/auto ...
creating policy directories ...
installing site policies ...
generating standalone-layout.bro ...
generating local-networks.bro ...
generating broctl-config.bro ...
generating broctl-config.sh ...
starting bro ...
Starting: vm-so-eth1
  * starting: netsniff-ng (full packet data)          [  OK  ]
  * starting: pcap_agent (sguil)                      [  OK  ]
  * starting: snort_agent-1 (sguil)                   [  OK  ]
  * starting: snort-1 (alert data)                    [  OK  ]
  * starting: barnyard2-1 (spooler, unified2 format)  [  OK  ]

Done.

Log onto ELSA and review 'logs indexed' and 'archived'
statistics visible in the top right corner of the web console.
Depending on your ELSA configuration and activity on your
network, these statistics will begin to climb.
```

I have successfully run this script using salt using a command similar to the following.
`sudo salt 'so-snsr*' cmd.run 'securityonion-elsa-reset -y -r'`

Below is the command line options for the script.
```
Security Onion ELSA Reset

  Options:
  -h         This message
  -l <file>  Log stdout and stderr to specified file (Use with '-y')
  -r         Reset tables and files
  -v         View only mode
  -y         Skip interactive mode

  Usage:
    Show help file.
    securityonion-elsa-reset -h

    Show relevant ELSA tables and files.
    securityonion-elsa-reset -v

    Reset ELSA index and archives.
    securityonion-elsa-reset -y -r
```

Is there any value in expanding the functionality of this script to allow the admin to select 'all', 'index' or 'archive' records only?  Presently this script removes everything but I notice there is a sister script that addresses archive records alone.  Is it better to have one script with multiple options or a couple scripts for select tasks?

This is my first pull request for anything, going through a crash course in git and github.  I welcome any constructive criticism on this pull request or the script it self.

Jason