### PR TITLE
add delaycompress for elsa logs

### DIFF
--- a/contrib/elsa.logrotate
+++ b/contrib/elsa.logrotate
@@ -5,5 +5,6 @@
   missingok
   notifempty
   compress
+  delaycompress
   maxage 60
 }


### PR DESCRIPTION
When a mailer is installed, occasionally, cron will notify the root user with the cryptic error:
  gzip: stdin: file size changed while zipping
Running logrotate in debug mode identifies the node.log file as the culprit.  Adding the "delaycompress" directive to the logrotate configuration for that file delays the compresson of that file until the next rotation cycle, preventing the email from cron.